### PR TITLE
fixed PHP Strict error

### DIFF
--- a/FormManager/Fields/Duplicable.php
+++ b/FormManager/Fields/Duplicable.php
@@ -81,7 +81,7 @@ class Duplicable extends Collection implements CollectionInterface {
 		return $this->createDuplicate($index, false);
 	}
 
-	public function prepareChildren ($parentPath) {
+	public function prepareChildren ($parentPath=null) {
 		$this->parentPath = $parentPath;
 
 		foreach ($this->children as $key => $child) {


### PR DESCRIPTION
Fixes an error with the incorrect function declaration of
prepareChildren in Fields/Duplicable.php. Specific error is Strict
Standards: Declaration of
FormManager\Fields\Duplicable::prepareChildren() should be compatible
with FormManager\Fields\Collection::prepareChildren($parentPath = NULL)
