### PR TITLE
replaced escaping function with htmlspecialchars

### DIFF
--- a/FormManager/Element.php
+++ b/FormManager/Element.php
@@ -7,16 +7,10 @@ class Element {
 	protected $attributes = [];
 	protected $data = [];
 	protected $html;
-	protected $encoding = 'UTF-8';
 
 	protected static function escape ($value) {
-		return htmlspecialchars($value, ENT_QUOTES, $this->encoding);
+		return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 	}
-    
-    public function setEscapeEncoding($encoding)
-    {
-        $this->encoding = $encoding;
-    }
 
 	public function __call ($name, $arguments) {
 		$this->attr($name, (array_key_exists(0, $arguments) ? $arguments[0] : true));


### PR DESCRIPTION
The escaping function could theoretically incorrectly escape input
sequences.
