### PR TITLE
Select input value issue

### DIFF
--- a/src/Inputs/Select.php
+++ b/src/Inputs/Select.php
@@ -101,7 +101,7 @@ class Select extends Input implements InputInterface
         foreach ($this->options as $value => $label) {
             $html .= '<option value="'.static::escape($value).'"';
 
-            if ($val == $value || (is_array($val) && in_array($value, $val))) {
+            if ($val === $value || (is_array($val) && in_array($value, $val))) {
                 $html .= ' selected';
             }
 


### PR DESCRIPTION
Thanks for the great library.

I came across an issue where I had the following options in my select

```
'' => ' -- Any --',
'0' => 'Studio',
'1' => '1 Bedroom',
'2' => '2 Bedrooms',
```

Unfortunately because php treats `'' == 0` as `true`, both of the top two options are treated as selected.

I've updated the comparison to `$val === $value` to fix this issue.
