### PR TITLE
Fixed Number validation when 0.0 is used as value

### DIFF
--- a/src/Inputs/Number.php
+++ b/src/Inputs/Number.php
@@ -16,7 +16,7 @@ class Number extends Input implements InputInterface
     {
         $value = $this->val();
 
-        if (!empty($value) && !filter_var($value, FILTER_VALIDATE_FLOAT)) {
+        if (!empty($value) && (filter_var($value, FILTER_VALIDATE_FLOAT) === false)) {
             $this->error(static::$error_message);
 
             return false;


### PR DESCRIPTION
If I use "0.0" string to validate a number, not empty check is returning true and filter_var returns "float(0)" and is validated as false.

You must check if filter_var returns false with type comparisons.

Regards.
