### PR TITLE
Examples System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+examples/vendor
+
 # MACOSX
 
 .DS_Store

--- a/examples/_footer.php
+++ b/examples/_footer.php
@@ -1,0 +1,5 @@
+    <script>
+        SyntaxHighlighter.all();
+    </script>
+    </body>
+</html>

--- a/examples/_header.php
+++ b/examples/_header.php
@@ -14,3 +14,12 @@
         <!-- End Syntax Highlighter -->
     </head>
     <body>
+    <h1>Form Manager Examples</h1>
+    <nav>
+        <ul>
+            <li>
+                <a href='index.php'>List of Examples</a>
+            </li>
+        </ul>
+    </nav>
+

--- a/examples/_header.php
+++ b/examples/_header.php
@@ -12,6 +12,11 @@
         <script src="http://alexgorbatchev.com/pub/sh/current/scripts/shBrushPhp.js" type="text/javascript"></script>
         <script src="http://alexgorbatchev.com/pub/sh/current/scripts/shAutoloader.js" type="text/javascript"></script>
         <!-- End Syntax Highlighter -->
+        <!-- Add Bootstrap -->
+        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
+        <script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+        <!-- End Bootstrap -->
     </head>
     <body>
     <h1>Form Manager Examples</h1>

--- a/examples/_header.php
+++ b/examples/_header.php
@@ -1,0 +1,16 @@
+<!doctype html>
+<html class="no-js" lang="">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>Form Builder Examples</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- Add Syntax Highlighter -->
+        <link href="http://alexgorbatchev.com/pub/sh/current/styles/shThemeDefault.css" rel="stylesheet" type="text/css" />
+        <script src="http://alexgorbatchev.com/pub/sh/current/scripts/shCore.js" type="text/javascript"></script>
+        <script src="http://alexgorbatchev.com/pub/sh/current/scripts/shBrushPhp.js" type="text/javascript"></script>
+        <script src="http://alexgorbatchev.com/pub/sh/current/scripts/shAutoloader.js" type="text/javascript"></script>
+        <!-- End Syntax Highlighter -->
+    </head>
+    <body>

--- a/examples/_list_examples.php
+++ b/examples/_list_examples.php
@@ -1,0 +1,18 @@
+<?php
+$html = [];
+$html[] = '<ol>';
+foreach (glob(__DIR__.'/example/*.php') as $examplePath) {
+    $exampleSlug = basename($examplePath);
+    $exampleSlug = preg_replace('/[^A-z0-9\-]/', '', $exampleSlug);
+    $exampleSlug = substr($exampleSlug, 0, -3);
+    $exampleName = ucwords(str_replace('-', ' ', $exampleSlug));
+    $html[] = '<li>';
+    $html[]     = '<a href  ="index.php';
+    $html[]     = '?'.http_build_query(['example' => $exampleSlug]);
+    $html[]     = '">';
+    $html[]     = $exampleName;
+    $html[]     = '</a>';
+    $html[] = '</li>';
+}
+$html[] = '<ol>';
+echo implode($html);

--- a/examples/_show_example.php
+++ b/examples/_show_example.php
@@ -1,13 +1,17 @@
+<?php
+    ob_start();
+    require $exampleFile;
+    $outputHtml = ob_get_clean();
+?>
 <h2>FormManager Example: <?php echo $exampleName ?></h2>
 <h3>Browser Output</h3>
-<?php require $exampleFile ?>
-
+<?php echo $outputHtml; ?>
 <h3>HTML Output</h3>
 <script type="syntaxhighlighter" class="brush: php"><![CDATA[
-<?=file_get_contents($exampleFileHtml);?>
+<?php echo Mihaeu\HtmlFormatter::format($outputHtml);?>
 ]]></script>
 
 <h3>Source</h3>
 <script type="syntaxhighlighter" class="brush: php"><![CDATA[
-<?=file_get_contents($exampleFile);?>
+<?php echo file_get_contents($exampleFile);?>
 ]]></script>

--- a/examples/_show_example.php
+++ b/examples/_show_example.php
@@ -1,0 +1,13 @@
+<h2>FormManager Example: <?php echo $exampleName ?></h2>
+<h3>Browser Output</h3>
+<?php require $exampleFile ?>
+
+<h3>HTML Output</h3>
+<script type="syntaxhighlighter" class="brush: php"><![CDATA[
+<?=file_get_contents($exampleFileHtml);?>
+]]></script>
+
+<h3>Source</h3>
+<script type="syntaxhighlighter" class="brush: php"><![CDATA[
+<?=file_get_contents($exampleFile);?>
+]]></script>

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -2,7 +2,8 @@
     "name": "form-manager/form-manager-examples",
     "description": "Working examples of form-manager",
     "require": {
-        "form-manager/form-manager": "^4.3"
+        "form-manager/form-manager": "^4.3",
+        "mihaeu/html-formatter": "^1.0"
     },
     "authors": [
         {

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "form-manager/form-manager-examples",
+    "description": "Working examples of form-manager",
+    "require": {
+        "form-manager/form-manager": "^4.3"
+    },
+    "authors": [
+        {
+            "name": "Sami Greenbury",
+            "email": "dude@patabugen.co.uk"
+        }
+    ]
+}

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -3,7 +3,8 @@
     "description": "Working examples of form-manager",
     "require": {
         "form-manager/form-manager": "^4.3",
-        "mihaeu/html-formatter": "^1.0"
+        "mihaeu/html-formatter": "^1.0",
+        "form-manager/bootstrap": "^2.0"
     },
     "authors": [
         {

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d703ac60503a2fe2ccd854c70adf8ef0",
+    "hash": "e0d68bff42d79aac627f553fe56e244d",
     "packages": [
         {
             "name": "form-manager/form-manager",
@@ -50,6 +50,46 @@
                 "validator"
             ],
             "time": "2015-05-13 17:58:07"
+        },
+        {
+            "name": "mihaeu/html-formatter",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mihaeu/html-formatter.git",
+                "reference": "a376177343ffe5484f8457f699237c1863b7cfd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mihaeu/html-formatter/zipball/a376177343ffe5484f8457f699237c1863b7cfd5",
+                "reference": "a376177343ffe5484f8457f699237c1863b7cfd5",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mihaeu": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Haeuslmann",
+                    "email": "haeuslmann@gmail.com"
+                }
+            ],
+            "description": "HTML Formatter pritifies HTML content by applying proper intendation (no tidy, purification, etc.).",
+            "homepage": "https://github.com/mihaeu/html-formatter",
+            "keywords": [
+                "clean",
+                "formatter",
+                "html",
+                "pretty"
+            ],
+            "time": "2013-11-26 11:55:02"
         }
     ],
     "packages-dev": [],

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -1,0 +1,63 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "d703ac60503a2fe2ccd854c70adf8ef0",
+    "packages": [
+        {
+            "name": "form-manager/form-manager",
+            "version": "v4.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/oscarotero/form-manager.git",
+                "reference": "5f7649ea7e4ba63425cc9cd424b3480f179a2936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/oscarotero/form-manager/zipball/5f7649ea7e4ba63425cc9cd424b3480f179a2936",
+                "reference": "5f7649ea7e4ba63425cc9cd424b3480f179a2936",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FormManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oscar Otero",
+                    "email": "oom@oscarotero.com",
+                    "homepage": "http://oscarotero.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP-HTML form manager",
+            "homepage": "https://github.com/oscarotero/form-manager",
+            "keywords": [
+                "data",
+                "form",
+                "html",
+                "validator"
+            ],
+            "time": "2015-05-13 17:58:07"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -4,8 +4,52 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e0d68bff42d79aac627f553fe56e244d",
+    "hash": "56bef916d657f991d315a8f78274be51",
     "packages": [
+        {
+            "name": "form-manager/bootstrap",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/oscarotero/form-manager-bootstrap.git",
+                "reference": "ff9338c41acf47b83155be5f53ec3000e80006be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/oscarotero/form-manager-bootstrap/zipball/ff9338c41acf47b83155be5f53ec3000e80006be",
+                "reference": "ff9338c41acf47b83155be5f53ec3000e80006be",
+                "shasum": ""
+            },
+            "require": {
+                "form-manager/form-manager": "4.3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FormManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Oscar Otero",
+                    "email": "oom@oscarotero.com",
+                    "homepage": "http://oscarotero.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "FormManager extension to create bootstrap like forms",
+            "homepage": "https://github.com/oscarotero/form-manager-bootstrap",
+            "keywords": [
+                "bootstrap",
+                "form",
+                "html"
+            ],
+            "time": "2015-05-15 10:19:46"
+        },
         {
             "name": "form-manager/form-manager",
             "version": "v4.3.7",

--- a/examples/example/bootstrap-fields-in-columns.php
+++ b/examples/example/bootstrap-fields-in-columns.php
@@ -1,0 +1,49 @@
+<p>
+    This example creates a form with a collection of fields and puts them
+    into two (or more) columns.
+</p>
+<?php
+
+use FormManager\Bootstrap as FB;
+
+$form = FB::form();
+
+$field1 = FB::text()->label('Field 1');
+$field2 = FB::text()->label('Field 2');
+$field3 = FB::text()->label('Field 3');
+
+$field4 = FB::text()->label('Field 4');
+$field5 = FB::text()->label('Field 5');
+$field6 = FB::text()->label('Field 6');
+
+// The Group will act as the 'row'
+$group = FB::group();
+
+// The keys in the array here are the names of each element
+$group->add([
+    'field1' => $field1,
+    'field2' => $field2,
+    'field3' => $field3,
+    'field4' => $field4,
+    'field5' => $field5,
+    'field6' => $field6,
+]);
+
+// You the need to set the width on each field accordingly. You can add
+// more than one class if you wish (e.g "col-sm-6 col-lg-4" )
+$group->set([
+    'columnSizing' => [
+        'field1' => 'col-sm-6',
+        'field2' => 'col-sm-6',
+        'field3' => 'col-sm-6',
+        'field4' => 'col-sm-6',
+        'field5' => 'col-sm-6',
+        'field6' => 'col-sm-6'
+    ]
+]);
+
+// If you give the group a key then all the fields will have their values grouped by that.
+// If the key is falsy then they won't (e.g 0, null or '')
+$form->add([$group]);
+
+echo $form;

--- a/examples/example/multiple-groups-without-arrays.php
+++ b/examples/example/multiple-groups-without-arrays.php
@@ -1,0 +1,34 @@
+<p>
+    Usually if you use a group then all fields within that group will be put into
+    HTML field arrays (e.g &lt;input name=group1[field1]&gt; ) which is often not the
+    desired outcome. You can get past this by having falsy group names.
+</p>
+<?php
+
+use FormManager\Bootstrap as FB;
+
+$form = FB::form();
+
+$field1 = FB::text()->label('Field 1');
+$field2 = FB::text()->label('Field 2');
+
+// The Group will act as the 'row'
+$group1 = FB::group();
+$group2 = FB::group();
+
+// The keys in the array here are the names of each element
+$group1->add([
+    'field1' => $field1,
+]);
+$group2->add([
+    'field2' => $field2,
+]);
+
+// If you give the group a key then all the fields will have their values grouped by that.
+// If the key is falsy then they won't (e.g 0, or '')
+$form->add([
+    0 => $group1,
+    '' => $group2,
+]);
+
+echo $form;

--- a/examples/example/multiple-submit-buttons.html
+++ b/examples/example/multiple-submit-buttons.html
@@ -1,6 +1,0 @@
-<form>
-    <div>
-        <button type="submit" value="save" name="submit">Save and View</button>
-        <button type="submit" value="saveAndCreate" name="submit">Save and create another</button>
-    </div>
-</form>

--- a/examples/example/multiple-submit-buttons.html
+++ b/examples/example/multiple-submit-buttons.html
@@ -1,0 +1,6 @@
+<form>
+    <div>
+        <button type="submit" value="save" name="submit">Save and View</button>
+        <button type="submit" value="saveAndCreate" name="submit">Save and create another</button>
+    </div>
+</form>

--- a/examples/example/multiple-submit-buttons.php
+++ b/examples/example/multiple-submit-buttons.php
@@ -1,0 +1,28 @@
+<p>
+    This example creates a form with two submit buttons. The given case is for
+    when you might want to have a "Save" button and a "Save and Create Another" button
+    for easily adding creating multiple records, for example.
+</p>
+<?php
+
+use FormManager\Builder as F;
+
+$form = F::form();
+
+$save = F::submit();
+$save->label('Save and View');
+
+$saveAndCreate = F::submit();
+$saveAndCreate->label('Save and create another');
+
+$submitGroup = F::choose();
+// The keys in the array here are the values of each element in the group
+$submitGroup->add([
+    'save' => $save,
+    'saveAndCreate' => $saveAndCreate,
+]);
+
+// The key you give when you pass the group to the form becomes the name
+$form->add(['submit' => $submitGroup]);
+
+echo $form;

--- a/examples/index.php
+++ b/examples/index.php
@@ -1,6 +1,13 @@
 <?php
-require __DIR__.'/_header.php';
 require __DIR__.'/vendor/autoload.php';
+require __DIR__.'/_header.php';
+?>
+<p>
+    Choose the template you wish to view below. Templates which begin with "bootstrap"
+    require the <a href='https://github.com/oscarotero/form-manager-bootstrap'>
+    FormManager Bootstrap</a> extension.
+</p>
+<?php
 if (!isset($_GET['example'])) {
     echo "<h2>Pick an Example</h2>";
     require __DIR__.'/_list_examples.php';

--- a/examples/index.php
+++ b/examples/index.php
@@ -1,0 +1,20 @@
+<?php
+    require __DIR__.'/_header.php';
+    require __DIR__.'/vendor/autoload.php';
+    // Get the requested example, and make it safe
+    $example = preg_replace('/[^A-z0-9\-]/', '', $_GET['example']);
+    $exampleFile = __DIR__.'/example/'.$example.'.php';
+?>
+
+<h1>Result</h1>
+<?php require $exampleFile ?>
+
+<h1>Source</h1>
+<script type="syntaxhighlighter" class="brush: php"><![CDATA[
+    <?=file_get_contents($exampleFile);?>
+]]></script>
+
+<?php require __DIR__.'/_footer.php'; ?>
+
+<?php
+require __DIR__.'/_footer.php';

--- a/examples/index.php
+++ b/examples/index.php
@@ -1,20 +1,23 @@
 <?php
-    require __DIR__.'/_header.php';
-    require __DIR__.'/vendor/autoload.php';
+require __DIR__.'/_header.php';
+require __DIR__.'/vendor/autoload.php';
+if (!isset($_GET['example'])) {
+    echo "<h2>Pick an Example</h2>";
+    require __DIR__.'/_list_examples.php';
+} else {
     // Get the requested example, and make it safe
     $example = preg_replace('/[^A-z0-9\-]/', '', $_GET['example']);
+    // Make a pretty display name for the example
+    $exampleName = ucwords(str_replace('-', ' ', $example));
+    // Get paths  to the files (And hmtl files)
     $exampleFile = __DIR__.'/example/'.$example.'.php';
-?>
+    $exampleFileHtml = __DIR__.'/example/'.$example.'.html';
+    if (!file_exists($exampleFile)) {
+        echo "<h2>Invalid Example</h2>";
+        require __DIR__.'/_list_examples.php';
+    } else {
+        require __DIR__.'/_show_example.php';
+    }
+}
 
-<h1>Result</h1>
-<?php require $exampleFile ?>
-
-<h1>Source</h1>
-<script type="syntaxhighlighter" class="brush: php"><![CDATA[
-    <?=file_get_contents($exampleFile);?>
-]]></script>
-
-<?php require __DIR__.'/_footer.php'; ?>
-
-<?php
 require __DIR__.'/_footer.php';

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,0 +1,19 @@
+# Viewing the Examples
+To view the examples you'll need to run them, clone this repo and then run composer install
+in the `examples` directory.
+
+Open index.php in your browser (through PHP) and everything shoild be simple.
+
+You may be able to see the examples online here:
+
+http://pata.cat/tools/form-manager/examples/index.php
+
+# Adding an Example
+To add an example simply create a new file in `examples/example` where the filename
+is the title of the example (with dashes in place of spaces and .php at the end). The
+file should contain a short description at the top followed by the code to create
+and output the form. Please keep your example as simple as is required to show the
+functionality required.
+
+The other example scripts will handle displaying it. See `examples/example/multiple-submit-buttons.php`
+for a simple example.

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -268,6 +268,7 @@ class Element implements ElementInterface
      */
     public function addClass($class)
     {
+        fb($class);
         $classes = $this->attr('class');
 
         if (!$classes) {


### PR DESCRIPTION
I've added the basis for being able to easily show example of using FormManager alongside their PHP and HTML output.

To add an example simple create a file in the `examples/example` directory with a short example at the top, and the form code below.

To really see the examples it's best to be able to run the code, I've hosted a copy of the examples here:

http://pata.cat/tools/form-manager/examples/index.php

which should be online for the foreseeable future. but anybody is welcome to host a new copy (or perhaps setup a git-pages).

Feel free to suggest better ways to achieve any of these examples.