### PR TITLE
remove method for ElementContainer

### DIFF
--- a/src/Elements/ElementContainer.php
+++ b/src/Elements/ElementContainer.php
@@ -211,6 +211,26 @@ class ElementContainer extends Element implements Iterator, ArrayAccess, Countab
     }
 
     /**
+     * Removes one or more children of the element.
+     *
+     * @param string|array $children
+     *
+     * @return $this
+     */
+    public function remove($children) {
+        if (!is_array($children))
+        {
+            $children = [$children];
+        }
+
+        foreach ($children as $offset) {
+            $this->offsetUnset($offset);
+        }
+        
+        return $this;
+    }
+
+    /**
      * Removes all children
      *
      * @return $this


### PR DESCRIPTION
I wanted to have a method to remove form fields without using the offsetUnset method.

$form = F::Form([
    'nome' => F::text()->label('O teu nome'),
    'apelido' => F::text()->label('O teu apelido'),
    'enviar' => F::submit()->html('Enviar'),
]);

$form->remove('nome);
or as array
$form->remove(['nome', 'apelido']);