### PR TITLE
fix array normalizing

### DIFF
--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -234,7 +234,7 @@ class Select extends ElementContainer implements InputInterface
         }
 
         //Normalize values
-        $value = array_keys(array_flip($value));
+        $value = array_unique(array_values($value));
 
         //check the selected values
         foreach ($value as $val) {

--- a/tests/Inputs/InputSelectTest.php
+++ b/tests/Inputs/InputSelectTest.php
@@ -36,7 +36,7 @@ class InputSelectTest extends BaseTest
 
         $select->val('2');
         $this->assertTrue($select->validate());
-        $this->assertSame(2, $select->val());
+        $this->assertSame('2', $select->val());
 
         $select->val('002');
         $this->assertTrue($select->validate());
@@ -69,7 +69,7 @@ class InputSelectTest extends BaseTest
         $this->assertCount(4, $select->options());
 
         $select->val('1');
-        $this->assertSame($select->val(), 1);
+        $this->assertSame($select->val(), '1');
         $this->assertCount(4, $select->options());
     }
 

--- a/tests/Inputs/InputSelectTest.php
+++ b/tests/Inputs/InputSelectTest.php
@@ -98,7 +98,7 @@ class InputSelectTest extends BaseTest
 
         $select->val(['1', '0']);
 
-        $this->assertSame([1, 0], $select->val());
+        $this->assertSame(['1', '0'], $select->val());
 
         $select->val(2);
 


### PR DESCRIPTION
in case when Select::val($value) $value is not integer or string, eg bool :
Select::applyValues(array $value) will not apply old normalize method, array_flip() will raise warning