### PR TITLE
Add an ability to set default messages for all inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,20 @@ All HTML5 field types are supported:
 This library uses internally [symfony/validation](https://symfony.com/doc/current/validation.html) to perform basic html5 validations and error reporting. HTML5 validation attributes like `required`, `maxlength`, `minlength`, `pattern`, etc are supported, in addition to intrinsic validations assigned to each input like email, url, date, etc.
 
 ```php
+//Set defaut error messages
+F::setErrorMessages([
+    'required' => 'The field is required'
+    'maxlength' => 'The field is too long, it must have {{ limit }} characters or less',
+]);
+
 $email = F::email();
+
+//You can also customize/translate the error messages
+$email->setErrorMessages([
+    'email' => 'The email is not valid',
+    'required' => 'The email is required',
+    'maxlength' => 'The email is too long, it must have {{ limit }} characters or less',
+]);
 
 $email->setValue('invalid-email');
 
@@ -105,13 +118,6 @@ echo $error;
 foreach ($error as $err) {
     echo $err->getMessage();
 }
-
-//You can also customize/translate the error messages
-$email->setErrorMessages([
-    'email' => 'The email is not valid',
-    'required' => 'The email is required',
-    'maxlength' => 'The email is too long, it must have {{ limit }} characters or less',
-]);
 
 //And add more symfony validators
 $ip = F::text();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -63,4 +63,13 @@ class Factory
             sprintf('Input %s not found', $name)
         );
     }
+
+    /**
+     * Set default error messages.
+     * @param array<string, string> $messages
+     */
+    public static function setErrorMessages(array $messages = []): void
+    {
+        ValidatorFactory::setMessages($messages);
+    }
 }

--- a/src/ValidatorFactory.php
+++ b/src/ValidatorFactory.php
@@ -13,6 +13,13 @@ use Symfony\Component\Validator\Constraints;
  */
 abstract class ValidatorFactory
 {
+    private static $messages = [];
+
+    public static function setMessages(array $messages): void
+    {
+        self::$messages = $messages;
+    }
+
     public static function createConstraints(Input $input): array
     {
         $constraints = [];
@@ -44,12 +51,13 @@ abstract class ValidatorFactory
         $messageKey = 'message'
     ): array {
         $messages = $input->getErrorMessages();
+        $message = $messages[$messageType] ?? self::$messages[$messageType] ?? null;
 
-        if (empty($messages[$messageType])) {
+        if (null === $message) {
             return $defaultOptions;
         }
 
-        return [$messageKey => $messages[$messageType]] + $defaultOptions;
+        return [$messageKey => $message] + $defaultOptions;
     }
 
     public static function number(Input $input): Constraint

--- a/tests/ValidatorFactoryTest.php
+++ b/tests/ValidatorFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+use PHPUnit\Framework\TestCase;
+use FormManager\ValidatorFactory;
+use FormManager\Inputs\Text;
+
+class ValidatorFactoryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        ValidatorFactory::setMessages([]);
+    }
+
+    public function testSetMessages(): void
+    {
+        ValidatorFactory::setMessages([
+            'required' => 'Default required message',
+        ]);
+
+        $input = new Text('Test input');
+        $input->setAttribute('required', true);
+        $input->setValue('');
+
+        $this->assertEquals('Default required message', (string) $input->getError());
+    }
+
+    public function testCustomMessage(): void
+    {
+        ValidatorFactory::setMessages([
+            'required' => 'Default required message',
+        ]);
+
+        $input = new Text('Test input');
+        $input->setAttribute('required', true);
+        $input->setValue('');
+        $input->setErrorMessages([
+            'required' => 'Custom required message',
+        ]);
+
+        $this->assertEquals('Custom required message', (string) $input->getError());
+    }
+}


### PR DESCRIPTION
This PR adds an ability to set default error messages for all inputs at once. This is useful for translation because you don't need to customize the message for each field individually:

```php
F::setErrorMessages([
    'required' => 'The field is required',
    'email' => 'The email is invalid',
]);
```