### PR TITLE
Support required radio groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ $radios = F::radioGroup([
 $radios->setValue('blue');
 ```
 
+If you need the radio group to be required, you should add the `required` attribute to at least one radio button:
+
+```php
+$radios = F::radioGroup([
+    'red' => F::radio('Red', ['required' => true]),
+    'blue' => 'Blue',
+    'green' => 'Green',
+]);
+```
+
 ### Submit group
 
 Special case to group several submit buttons under the same name but different values:

--- a/src/Groups/InputGroup.php
+++ b/src/Groups/InputGroup.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use ArrayIterator;
 use FormManager\InputInterface;
 use FormManager\NodeInterface;
+use FormManager\ValidationError;
 use IteratorAggregate;
 
 /**
@@ -41,6 +42,7 @@ abstract class InputGroup implements InputInterface, ArrayAccess, IteratorAggreg
     {
         $input->setAttribute('value', $value);
         $input->setName($this->name);
+        $input->setParentNode($this);
 
         $this->inputs[$value] = $input;
     }
@@ -89,6 +91,17 @@ abstract class InputGroup implements InputInterface, ArrayAccess, IteratorAggreg
         }
 
         return true;
+    }
+
+    public function getError(): ?ValidationError
+    {
+        foreach ($this->inputs as $input) {
+            if ($error = $input->getError()) {
+                return $error;
+            }
+        }
+
+        return null;
     }
 
     public function setName(string $name): InputInterface

--- a/src/Inputs/Radio.php
+++ b/src/Inputs/Radio.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace FormManager\Inputs;
 
+use FormManager\Groups\RadioGroup;
 use FormManager\InputInterface;
 
 /**
@@ -32,6 +33,16 @@ class Radio extends Input
 
         if (!empty($value) && (string) $this->getAttribute('value') === (string) $value) {
             return $this->setAttribute('checked', true);
+        }
+
+        $parent = $this->getParentNode();
+
+        if ($parent instanceof RadioGroup) {
+            if (!empty($value) && isset($parent[(string) $value])) {
+                unset($this->validators['required']);
+            } else {
+                $this->validators['required'] = 'required';
+            }
         }
 
         return $this->removeAttribute('checked');

--- a/tests/Groups/RadioGroupTest.php
+++ b/tests/Groups/RadioGroupTest.php
@@ -79,4 +79,25 @@ class RadioGroupTest extends TestCase
 
         $this->assertEquals(['name', 'surname', 'address'], $keys);
     }
+
+    public function testRequired(): void
+    {
+        $group = new RadioGroup([
+            'male' => new Radio('Male', ['required' => true]),
+            'female' => 'Female',
+        ]);
+
+        $this->assertFalse($group->isValid());
+        $this->assertSame('This value should not be blank.', (string) $group->getError());
+
+        $group->setValue('invalid');
+        $this->assertFalse($group->isValid());
+        $this->assertSame('This value should not be blank.', (string) $group->getError());
+
+        $group->setValue('male');
+        $this->assertTrue($group->isValid());
+
+        $group->setValue('female');
+        $this->assertTrue($group->isValid());
+    }
 }


### PR DESCRIPTION
This PR adds support for making radio groups required.

https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#attr-input-required

> For radio buttons, the [required](https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#attr-input-required) attribute is satisfied if any of the radio buttons in the [group](https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#radio-button-group) is selected. Thus, in the following example, any of the radio buttons can be checked, not just the one marked as required:

Example:

```php
$colors = F::radioGroup([
    'red' => F::radio('Red', ['required' => true]),   
    'blue' => 'Blue',                                                                                                                          
    'green' => 'Green',
]);                                                                                                                       );
```