### PR TITLE
Set custom validator

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,6 +3,8 @@
 namespace FormManager;
 
 use InvalidArgumentException;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Factory class to create all nodes.
@@ -42,6 +44,11 @@ class Factory
     ];
 
     /**
+     * @var ?ValidatorInterface
+     */
+    private static $validator = null;
+
+    /**
      * Factory to create input nodes
      * @param mixed $arguments
      */
@@ -71,5 +78,26 @@ class Factory
     public static function setErrorMessages(array $messages = []): void
     {
         ValidatorFactory::setMessages($messages);
+    }
+
+    /**
+     * Set a validator instance.
+     * @param ValidatorInterface $validator
+     */
+    public static function setValidator(ValidatorInterface $validator): void
+    {
+        self::$validator = $validator;
+    }
+
+    /**
+     * Get the validator instance.
+     */
+    public static function getValidator(): ValidatorInterface
+    {
+        if (null === self::$validator) {
+            return self::$validator = Validation::createValidator();
+        }
+
+        return self::$validator;
     }
 }

--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -6,7 +6,6 @@ namespace FormManager;
 use FormManager\Inputs\Input;
 use IteratorAggregate;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
-use Symfony\Component\Validator\Validation;
 use Traversable;
 
 /**
@@ -24,7 +23,7 @@ class ValidationError implements IteratorAggregate
             return null;
         }
 
-        $validator = Validation::createValidator();
+        $validator = Factory::getValidator();
         $violations = $validator->validate($input->getValue(), $constraints);
 
         if (count($violations)) {

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types = 1);
+
+namespace FormManager\Tests;
+
+use FormManager\Factory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class FactoryTest extends TestCase
+{
+    public function testGetValidator()
+    {
+        $this->assertInstanceOf(ValidatorInterface::class, Factory::getValidator());
+    }
+
+    public function testSetValidator()
+    {
+        $validator = Validation::createValidator();
+
+        Factory::setValidator($validator);
+
+        $this->assertSame($validator, Factory::getValidator());
+    }
+}


### PR DESCRIPTION
This PR adds an ability to set a custom validator using new `Factory::setValidator()` method. It may be useful, for example, if you want to customize translation messages and etc.

```sh
composer require symfony/translation symfony/config
```

```php
use FormManager\Factory as F;
use Symfony\Component\Translation\Loader\XliffFileLoader;
use Symfony\Component\Translation\Translator;
use Symfony\Component\Validator\Validation;

$locale = 'ru';

$translationsPath = dirname((new \ReflectionClass(Validation::class))->getFileName()) . '/Resources/translations';
$translationFile = sprintf('%s/validators.%s.xlf', $translationsPath, $locale);

$translator = new Translator($locale);
$translator->addLoader('xliff', new XliffFileLoader());
$translator->addResource('xliff', $translationFile, $locale, 'validators');

F::setValidator(
    Validation::createValidatorBuilder()
        ->setTranslator($translator)
        ->setTranslationDomain('validators')
        ->getValidator(),
);
```