### PR TITLE
Support symfony/validator v6 and v7

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -5,4 +5,5 @@ parameters:
     paths:
         - src
         - tests
-#    ignoreErrors:
+    excludePaths:
+        - src/Constraints/OptionalLength6Validator.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [7.0.0] - unreleased
 ### Added
 - Support until PHP 8.4
+- Added support for `symfony/validator` v6 (LTS) and v7.
 
 ## Changed
 - Minimum requirement is `php >= 7.2`
-- Upgraded to `symfony/validator` v5 ([without active support anymore, security fixes only until 2028](https://endoflife.date/symfony))
+- Upgraded `symfony/validator` to v5.4 
+  - no active support anymore
+  - [security fixes until 2028 though!](https://endoflife.date/symfony)
+  - the pinned version to 5.4 is to avoid outdated and buggy versions that we cannot rely on.
+
 
 ## [6.1.2] - 2021-07-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 [![testing](https://github.com/oscarotero/form-manager/actions/workflows/main.yaml/badge.svg)](https://github.com/oscarotero/form-manager/actions/workflows/main.yaml)
 
-> ### Note: this is the documentation of FormManager 6.x 
-> For v5.x version [Click here](https://github.com/oscarotero/form-manager/tree/v5)
+> ### Note: this is the documentation of FormManager 7.x 
+> For v6.x version [Click here](https://github.com/oscarotero/form-manager/tree/v6)
 
 ## Installation:
 
 This package requires `PHP>=7.2` and is available on [Packagist](https://packagist.org/packages/form-manager/form-manager):
+
+Supports `symfony/validator` v5, v6 and v7.
 
 ```
 composer require form-manager/form-manager

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=7.2",
-        "symfony/validator": "^5"
+        "symfony/validator": "^5.4 || ^6.4 || ^7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",

--- a/src/Constraints/OptionalLength6.php
+++ b/src/Constraints/OptionalLength6.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace FormManager\Constraints;
+
+use Symfony\Component\Validator\Constraints\Length;
+
+class OptionalLength6 extends Length
+{
+
+}

--- a/src/Constraints/OptionalLength6Validator.php
+++ b/src/Constraints/OptionalLength6Validator.php
@@ -7,7 +7,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\LengthValidator;
 
 /**
- * Optional length validator for Symfony Validator v6
+ * Optional length validator for Symfony Validator v7
  */
 class OptionalLength6Validator extends LengthValidator
 {

--- a/src/Constraints/OptionalLength6Validator.php
+++ b/src/Constraints/OptionalLength6Validator.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace FormManager\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\LengthValidator;
+
+/**
+ * Optional length validator for Symfony Validator v6
+ */
+class OptionalLength6Validator extends LengthValidator
+{
+    /**
+     * @{inheritdoc}
+     */
+    public function validate(mixed $value, Constraint $constraint)
+    {
+        if ('' === $value) {
+            return;
+        }
+
+        parent::validate($value, $constraint);
+    }
+}

--- a/src/Constraints/OptionalLength7.php
+++ b/src/Constraints/OptionalLength7.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace FormManager\Constraints;
+
+use Symfony\Component\Validator\Constraints\Length;
+
+class OptionalLength7 extends Length
+{
+
+}

--- a/src/Constraints/OptionalLength7Validator.php
+++ b/src/Constraints/OptionalLength7Validator.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace FormManager\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\LengthValidator;
+
+/**
+ * Optional length validator for Symfony Validator v6
+ */
+class OptionalLength7Validator extends LengthValidator
+{
+    /**
+     * @{inheritdoc}
+     */
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if ('' === $value) {
+            return;
+        }
+
+        parent::validate($value, $constraint);
+    }
+}

--- a/src/ValidatorFactory.php
+++ b/src/ValidatorFactory.php
@@ -4,9 +4,14 @@ declare(strict_types = 1);
 namespace FormManager;
 
 use FormManager\Inputs\Input;
+use PHPUnit\Util\Exception;
+use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints;
+use Symfony\Component\Validator\Constraints\LengthValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Helper to build the validators
@@ -160,9 +165,7 @@ abstract class ValidatorFactory
 
     public static function length(Input $input): Constraint
     {
-        $options = [
-            'allowEmptyString' => true,
-        ];
+        $options = [];
 
         $minlength = $input->getAttribute('minlength');
         $maxlength = $input->getAttribute('maxlength');
@@ -175,7 +178,34 @@ abstract class ValidatorFactory
             $options += self::options($input, 'maxlength', ['max' => $maxlength], 'maxMessage');
         }
 
-        return new Constraints\Length($options);
+        switch (self::getValidatorVersion()) {
+            case 7:
+                return new \FormManager\Constraints\OptionalLength7($options);
+            case 6:
+                return new \FormManager\Constraints\OptionalLength6($options);
+            case 5:
+                $options['allowEmptyString'] = true;
+                return new Constraints\Length($options);
+        }
+    }
+
+    private static function getValidatorVersion(): int
+    {
+        if (property_exists(Constraints\Length::class, 'allowEmptyString')) {
+            return 5;
+        }
+
+        $reflection = new ReflectionClass(LengthValidator::class);
+        $hasReturnType = $reflection->getMethod('validate')->hasReturnType();
+        if (!$hasReturnType) {
+            return 6;
+        }
+
+        if ($hasReturnType) {
+            return 7;
+        }
+
+        throw new RuntimeException('Cannot determine symfony/validator version. Please report this on GitHub.');
     }
 
     public static function max(Input $input): Constraint

--- a/src/ValidatorFactory.php
+++ b/src/ValidatorFactory.php
@@ -178,14 +178,15 @@ abstract class ValidatorFactory
             $options += self::options($input, 'maxlength', ['max' => $maxlength], 'maxMessage');
         }
 
-        switch (self::getValidatorVersion()) {
-            case 7:
-                return new \FormManager\Constraints\OptionalLength7($options);
-            case 6:
-                return new \FormManager\Constraints\OptionalLength6($options);
-            case 5:
-                $options['allowEmptyString'] = true;
-                return new Constraints\Length($options);
+        $version = self::getValidatorVersion();
+
+        if ($version === 7) {
+            return new \FormManager\Constraints\OptionalLength7($options);
+        } elseif ($version === 6) {
+            return new \FormManager\Constraints\OptionalLength6($options);
+        } else {
+            $options['allowEmptyString'] = true;
+            return new Constraints\Length($options);
         }
     }
 


### PR DESCRIPTION
Hi,

This will give long life to the project. Supporting v5, v6 and v7 of `symfony/validator` in this manner allows us to fully support until php8.4 in a backward compatible manner.

